### PR TITLE
Radio USRP: replace boost::thread with sdt::thread

### DIFF
--- a/src/common/Module/Radio/Radio_USRP/Radio_USRP.cpp
+++ b/src/common/Module/Radio/Radio_USRP/Radio_USRP.cpp
@@ -140,7 +140,7 @@ void Radio_USRP<R>
 	if (this->threaded && !this->start_thread_send)
 	{
 		this->start_thread_send = true;
-		this->send_thread = boost::thread(&Radio_USRP::thread_function_send, this);
+		this->send_thread = std::thread(&Radio_USRP::thread_function_send, this);
 	}
 
 	if (threaded)
@@ -163,7 +163,7 @@ void Radio_USRP<R>
 	if (this->threaded && !this->start_thread_receive)
 	{
 		this->start_thread_receive = true;
-		this->receive_thread = boost::thread(&Radio_USRP::thread_function_receive, this);
+		this->receive_thread = std::thread(&Radio_USRP::thread_function_receive, this);
 	}
 
 	if (threaded)

--- a/src/common/Module/Radio/Radio_USRP/Radio_USRP.hpp
+++ b/src/common/Module/Radio/Radio_USRP/Radio_USRP.hpp
@@ -37,8 +37,8 @@ private:
 	uhd::rx_streamer::sptr      rx_stream;
 	uhd::tx_streamer::sptr      tx_stream;
 
-	boost::thread send_thread;
-	boost::thread receive_thread;
+	std::thread send_thread;
+	std::thread receive_thread;
 
 	const bool threaded;
 	const bool rx_enabled;


### PR DESCRIPTION
Replace instances of boost::thread by std::thread,
inside of the Radio_USRP files.

This reduces dependency on Boost and its versions