### PR TITLE
Fix offset in scrambling sequence

### DIFF
--- a/src/common/Module/Scrambler/Scrambler_PL/Scrambler_PL.hxx
+++ b/src/common/Module/Scrambler/Scrambler_PL/Scrambler_PL.hxx
@@ -63,8 +63,8 @@ __scramble(D *X_N1, D *X_N2, bool scr_flag, const int frame_id)
 
 	for(int i = this->start_ix; i < this->N/2; i++)
 	{
-		int R_lsb     = this->PL_RAND_SEQ[i] % 2;
-		int R_msb     = this->PL_RAND_SEQ[i] / 2;
+		int R_lsb     = this->PL_RAND_SEQ[i-this->start_ix] % 2;
+		int R_msb     = this->PL_RAND_SEQ[i-this->start_ix] / 2;
 		int R_real    = (1 - R_lsb) * (-2 * R_msb +1); // real part
 		int R_imag    = R_lsb       * (-2 * R_msb +1); // imag part
 		R_imag        = (2 * scr_flag -1) * R_imag; // conjugate if scr_flag == false, i.e. descrambling

--- a/src/common/Module/Synchronizer/Synchronizer_freq/Synchronizer_freq_coarse/Synchronizer_freq_coarse_DVBS2_aib.cpp
+++ b/src/common/Module/Synchronizer/Synchronizer_freq/Synchronizer_freq_coarse/Synchronizer_freq_coarse_DVBS2_aib.cpp
@@ -27,7 +27,7 @@ Synchronizer_freq_coarse_DVBS2_aib<R>
 	// std::cerr << "# PL rand seq size             = " << this->PL_RAND_SEQ.size() << std::endl;
 	for (size_t i = 0; i < this->PL_RAND_SEQ.size(); i++)
 	{
-		this->scrambled_pilots[i] = std::complex<R>(std::cos((R)M_PI_2*((R)PL_RAND_SEQ[i]+0.5)), std::sin((R)M_PI_2*((R)PL_RAND_SEQ[i]+0.5)));
+		this->scrambled_pilots[i] = i < 90 ? 0 : std::complex<R>(std::cos((R)M_PI_2*((R)PL_RAND_SEQ[i-90]+0.5)), std::sin((R)M_PI_2*((R)PL_RAND_SEQ[i-90]+0.5)));
 	}
 }
 


### PR DESCRIPTION
The PLFRAME should be scrambled by the PL scrambling sequence, starting with the first non-header symbol. This offset is captured by `start_ix` (with the value 90), but is both used when indexing the symbols and the scrambling sequence. This means the first 90 scrambling sequence bits are never used.

I'm not sure how `scrambled_pilots` are used in `Synchronizer_freq_coarse_DVBS2_aib.cpp`, but the modification in that file at least makes `dvbs2_tx_rx` report low BER/FER again.

Output from `dvbs2_tx_rx`:

```
# --------------------------------||--------------------------------------------------------||---------------------
#        Signal Noise Ratio       ||    Bit Error Rate (BER) and Frame Error Rate (FER)     ||  Global throughput
#              (SNR)              ||                                                        ||  and elapsed time
# --------------------------------||--------------------------------------------------------||---------------------
# ----------|----------|----------||------------|----------|----------|----------|----------||----------|----------
#     Sigma |    Es/N0 |    Eb/N0 ||        FRA |       BE |       FE |      BER |      FER ||  SIM_THR |    ET/RT
#           |     (dB) |     (dB) ||            |          |          |          |          ||   (Mb/s) | (hhmmss)
# ----------|----------|----------||------------|----------|----------|----------|----------||----------|----------
     0.3691 |     5.65 |     3.20 ||        100 |    26891 |      100 | 1.89e-02 | 1.00e+00 ||    1.374 | 00h00'01
     0.3648 |     5.75 |     3.30 ||        100 |    25738 |      100 | 1.81e-02 | 1.00e+00 ||    1.259 | 00h00'01
     0.3607 |     5.85 |     3.40 ||        105 |    20565 |      100 | 1.38e-02 | 9.52e-01 ||    1.410 | 00h00'01
     0.3565 |     5.95 |     3.50 ||        126 |    16433 |      100 | 9.16e-03 | 7.94e-01 ||    1.702 | 00h00'01
     0.3524 |     6.05 |     3.60 ||        251 |    13602 |      100 | 3.81e-03 | 3.98e-01 ||    2.755 | 00h00'01
     0.3484 |     6.15 |     3.70 ||        703 |    11719 |      100 | 1.17e-03 | 1.42e-01 ||    5.788 | 00h00'01
     0.3444 |     6.25 |     3.80 ||        490 |    12104 |      100 | 1.74e-03 | 2.04e-01 ||    4.728 | 00h00'01
     0.3405 |     6.35 |     3.90 ||      41064 |    11277 |      100 | 1.93e-05 | 2.44e-03 ||   24.143 | 00h00'24
     0.3366 |     6.45 |     4.00 ||     846718 |    10594 |      100 | 8.79e-07 | 1.18e-04 ||   35.129 | 00h05'43
     0.3327 |     6.55 |     4.10 ||   11896278 |    10206 |      100 | 6.03e-08 | 8.41e-06 ||   38.827 | 01h12'40   '49  *

```

I didn't run a long test before applying the changes, but a quick run near the Eb/N0 threshold suggests performance is not far off:

```
# --------------------------------||--------------------------------------------------------||---------------------
#        Signal Noise Ratio       ||    Bit Error Rate (BER) and Frame Error Rate (FER)     ||  Global throughput
#              (SNR)              ||                                                        ||  and elapsed time
# --------------------------------||--------------------------------------------------------||---------------------
# ----------|----------|----------||------------|----------|----------|----------|----------||----------|----------
#     Sigma |    Es/N0 |    Eb/N0 ||        FRA |       BE |       FE |      BER |      FER ||  SIM_THR |    ET/RT
#           |     (dB) |     (dB) ||            |          |          |          |          ||   (Mb/s) | (hhmmss)
# ----------|----------|----------||------------|----------|----------|----------|----------||----------|----------
     0.3524 |     6.05 |     3.60 ||        213 |    13959 |      100 | 4.60e-03 | 4.69e-01 ||    2.587 | 00h00'01
     0.3484 |     6.15 |     3.70 ||        960 |    12382 |      100 | 9.06e-04 | 1.04e-01 ||    6.451 | 00h00'02
     0.3444 |     6.25 |     3.80 ||       4502 |    10923 |      100 | 1.70e-04 | 2.22e-02 ||   12.981 | 00h00'04
     0.3405 |     6.35 |     3.90 ||      36202 |    11819 |      100 | 2.29e-05 | 2.76e-03 ||   23.798 | 00h00'21
```